### PR TITLE
Recipe with multiple outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About typer-feedstock
-=====================
+About typer-suite-feedstock
+===========================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/typer-feedstock/blob/main/LICENSE.txt)
 
@@ -41,27 +41,30 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-typer-green.svg)](https://anaconda.org/conda-forge/typer) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/typer.svg)](https://anaconda.org/conda-forge/typer) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/typer.svg)](https://anaconda.org/conda-forge/typer) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/typer.svg)](https://anaconda.org/conda-forge/typer) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-typer--cli-green.svg)](https://anaconda.org/conda-forge/typer-cli) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/typer-cli.svg)](https://anaconda.org/conda-forge/typer-cli) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/typer-cli.svg)](https://anaconda.org/conda-forge/typer-cli) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/typer-cli.svg)](https://anaconda.org/conda-forge/typer-cli) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-typer--slim-green.svg)](https://anaconda.org/conda-forge/typer-slim) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/typer-slim.svg)](https://anaconda.org/conda-forge/typer-slim) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/typer-slim.svg)](https://anaconda.org/conda-forge/typer-slim) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/typer-slim.svg)](https://anaconda.org/conda-forge/typer-slim) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-typer--slim--standard-green.svg)](https://anaconda.org/conda-forge/typer-slim-standard) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/typer-slim-standard.svg)](https://anaconda.org/conda-forge/typer-slim-standard) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/typer-slim-standard.svg)](https://anaconda.org/conda-forge/typer-slim-standard) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/typer-slim-standard.svg)](https://anaconda.org/conda-forge/typer-slim-standard) |
 
-Installing typer
-================
+Installing typer-suite
+======================
 
-Installing `typer` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `typer-suite` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `typer` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `typer, typer-cli, typer-slim, typer-slim-standard` can be installed with `conda`:
 
 ```
-conda install typer
+conda install typer typer-cli typer-slim typer-slim-standard
 ```
 
 or with `mamba`:
 
 ```
-mamba install typer
+mamba install typer typer-cli typer-slim typer-slim-standard
 ```
 
 It is possible to list all of the versions of `typer` available on your platform with `conda`:
@@ -131,17 +134,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating typer-feedstock
-========================
+Updating typer-suite-feedstock
+==============================
 
-If you would like to improve the typer recipe or build a new
+If you would like to improve the typer-suite recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/typer-feedstock are
+Note that all branches in the conda-forge/typer-suite-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,18 @@
 {% set min_python = "python >=3.8" %}
 {% set version = "0.12.0" %}
-{% set min_python = "python >=3.8" %}
 
 package:
-  name: typer
+  name: typer-suite
   version: {{ version }}
 
 source:
   - folder: dist
+    url: https://pypi.io/packages/source/t/typer-slim/typer_slim-{{ version }}.tar.gz
+    sha256: 3e8a3f17286b173d76dca0fd4e02651c9a2ce1467b3754876b1ac4bd72572beb
+  - folder: dist/typer_cli_package
+    url: https://pypi.io/packages/source/t/typer-cli/typer_cli-{{ version }}.tar.gz
+    sha256: 603ed3d5a278827bd497e4dc73a39bb714b230371c8724090b0de2abdcdd9f6e
+  - folder: dist/typer_package
     url: https://pypi.io/packages/source/t/typer/typer-{{ version }}.tar.gz
     sha256: 900fe786ce2d0ea44653d3c8ee4594a22a496a3104370ded770c992c5e3c542d
   - folder: src
@@ -15,37 +20,86 @@ source:
     sha256: 04e1914b981da512e22a6c4021df877a54b95bf123fa2af4cbdb25950c2b72d5
 
 build:
-  noarch: python
   number: 0
-  script: cd dist && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
-requirements:
-  host:
-    - {{ min_python }}
-    - pdm-backend
-    - pip
-  run:
-    - {{ min_python }}
-    - click >=8.0.0
-    - colorama >=0.4.3,<0.5.0
-    - rich >=10.11.0,<14.0.0
-    - shellingham >=1.3.0,<2.0.0
-    - typing-extensions >=3.7.4.3
-
-test:
-  source_files:
-    - src/tests
-    - src/docs_src
-  imports:
-    - typer
-  requires:
-    - coverage
-    - pip
-    - pytest-sugar
-  commands:
-    - pip check
-    - cd src && coverage run --source typer --branch -m pytest -vv --color=yes --tb=long -k "not ((multiple_values and main) or completion)"
-    - coverage report --show-missing --skip-covered --fail-under=74
+outputs:
+  - name: typer-slim
+    build:
+      noarch: python
+      script: cd dist && python -m pip install . -vv --no-deps --no-build-isolation
+    requirements:
+      host:
+        - {{ min_python }}
+        - pdm-backend
+        - pip
+      run:
+        - {{ min_python }}
+        - click >=8.0.0
+        - colorama >=0.4.3,<0.5.0
+        - typing-extensions >=3.7.4.3
+  - name: typer-slim-standard
+    build:
+      noarch: python
+    requirements:
+      host:
+        - {{ min_python }}
+      run:
+        - {{ min_python }}
+        - {{ pin_subpackage('typer-slim', max_pin="x.x.x") }}
+        - rich >=10.11.0,<14.0.0
+        - shellingham >=1.3.0,<2.0.0
+    test:
+      source_files:
+        - src/tests
+        - src/docs_src
+      imports:
+        - typer
+      requires:
+        - coverage
+        - pip
+        - pytest-sugar
+      commands:
+        - pip check
+        - cd src && coverage run --source typer --branch -m pytest -vv --color=yes --tb=long -k "not ((multiple_values and main) or completion)"
+        - coverage report --show-missing --skip-covered --fail-under=66
+  - name: typer-cli
+    build:
+      noarch: python
+      script: cd dist/typer_cli_package && python -m pip install . -vv --no-deps --no-build-isolation
+      entry_points:
+        - typer = typer.cli:main
+    requirements:
+      host:
+        - {{ min_python }}
+        - pdm-backend
+        - pip
+      run:
+        - {{ min_python }}
+        - {{ pin_subpackage('typer-slim-standard', max_pin="x.x.x") }}
+    test:
+      requires:
+        - pip
+      commands:
+        - typer --help
+        - pip check
+  - name: typer
+    build:
+      noarch: python
+      script: cd dist/typer_package && python -m pip install . -vv --no-deps --no-build-isolation
+    requirements:
+      host:
+        - {{ min_python }}
+        - pdm-backend
+        - pip
+      run:
+        - {{ min_python }}
+        - {{ pin_subpackage('typer-slim-standard', max_pin="x.x.x") }}
+        - {{ pin_subpackage('typer-cli', max_pin="x.x.x") }}
+    test:
+      requires:
+        - pip
+      commands:
+        - pip check
 
 about:
   home: https://github.com/tiangolo/typer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,12 @@ outputs:
       run:
         - {{ min_python }}
         - click >=8.0.0
-        - colorama >=0.4.3,<0.5.0
         - typing-extensions >=3.7.4.3
+    test:
+      requires:
+        - pip
+      commands:
+        - pip check
   - name: typer-slim-standard
     build:
       noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set min_python = "python >=3.8" %}
-{% set version = "0.12.0" %}
+{% set version = "0.12.1" %}
 
 package:
   name: typer-suite
@@ -8,16 +8,16 @@ package:
 source:
   - folder: dist
     url: https://pypi.io/packages/source/t/typer-slim/typer_slim-{{ version }}.tar.gz
-    sha256: 3e8a3f17286b173d76dca0fd4e02651c9a2ce1467b3754876b1ac4bd72572beb
+    sha256: a1d74b0ffad59a42fc06bc9e9661402267f0e1c072f5ac8b751392e6a24ff37c
   - folder: dist/typer_cli_package
     url: https://pypi.io/packages/source/t/typer-cli/typer_cli-{{ version }}.tar.gz
-    sha256: 603ed3d5a278827bd497e4dc73a39bb714b230371c8724090b0de2abdcdd9f6e
+    sha256: 2576e55d3418b07843cfefae1f3c65a9e47156d34abeccc6c2039691bd5286c6
   - folder: dist/typer_package
     url: https://pypi.io/packages/source/t/typer/typer-{{ version }}.tar.gz
-    sha256: 900fe786ce2d0ea44653d3c8ee4594a22a496a3104370ded770c992c5e3c542d
+    sha256: 72d218ef3c686aed9c6ff3ca25b238aee0474a1628b29c559b18b634cfdeca88
   - folder: src
     url: https://github.com/tiangolo/typer/archive/refs/tags/{{ version }}.tar.gz
-    sha256: 04e1914b981da512e22a6c4021df877a54b95bf123fa2af4cbdb25950c2b72d5
+    sha256: 043b6ed2972aed30f9e38f78c175b49939ffb2cb09334c7c4a1f19c3bdd72490
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,11 +36,6 @@ outputs:
         - {{ min_python }}
         - click >=8.0.0
         - typing-extensions >=3.7.4.3
-    test:
-      requires:
-        - pip
-      commands:
-        - pip check
   - name: typer-slim-standard
     build:
       noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,11 +76,8 @@ outputs:
         - {{ min_python }}
         - {{ pin_subpackage('typer-slim-standard', max_pin="x.x.x") }}
     test:
-      requires:
-        - pip
       commands:
         - typer --help
-        - pip check
   - name: typer
     build:
       noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = "0.11.1" %}
+{% set min_python = "python >=3.8" %}
+{% set version = "0.12.0" %}
 {% set min_python = "python >=3.8" %}
 
 package:
@@ -8,10 +9,10 @@ package:
 source:
   - folder: dist
     url: https://pypi.io/packages/source/t/typer/typer-{{ version }}.tar.gz
-    sha256: f5ae987b97ebbbd59182f8e84407bbc925bc636867fa007bce87a7a71ac81d5c
+    sha256: 900fe786ce2d0ea44653d3c8ee4594a22a496a3104370ded770c992c5e3c542d
   - folder: src
     url: https://github.com/tiangolo/typer/archive/refs/tags/{{ version }}.tar.gz
-    sha256: ab98bf9140ff8ffb91b3055d3a214c005e86410c44b0195123c33654db527f99
+    sha256: 04e1914b981da512e22a6c4021df877a54b95bf123fa2af4cbdb25950c2b72d5
 
 build:
   noarch: python


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* ~~Bumped the build number (if the version is unchanged)~~
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This superseeds #23 and #24

Closes #23 
Closes #24
<!--
Please add any other relevant info below:
-->

It transform the recipe to produce multiple outputs:
- typer-slim
- typer-slim-standard (reflect typer-slim[standard])
- typer-cli
- typer

The tests suite is executed against `typer-slim-standard` because some of them require rich to be executed.

The coverage expectation has been reduced to 66 as the applied filter skip some of the tests preventing higher coverage.
